### PR TITLE
send crash report to rollbar

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 func sendReport(err error) {
-	if !metavars.ReportEnabled {
+	if metavars.ReportDisabled {
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -91,8 +91,8 @@ func main() {
 				rollbar.Error(rollbar.ERR, fmt.Errorf("%s", rec))
 				rollbar.Wait()
 			}
+			os.Exit(1)
 		}
-		os.Exit(1)
 	}()
 
 	cli.VersionPrinter = func(c *cli.Context) {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -45,14 +46,14 @@ func globalOptions(c *cli.Context) error {
 		log.Debug("Loglevel is set to DebugLevel.")
 	}
 
-	if c.GlobalBool("enablereport") {
-		metavars.ReportEnabled = true
-
-		// initialize rollbar client
-		rollbar.Token = RollbarToken
-		rollbar.Environment = versions.Branch
-		rollbar.Platform = "client"
+	if c.GlobalBool("disablereport") || versions.Revision == "local-build" {
+		metavars.ReportDisabled = true
 	}
+
+	// initialize rollbar client
+	rollbar.Token = RollbarToken
+	rollbar.Environment = versions.Branch
+	rollbar.Platform = "client"
 
 	return nil
 }
@@ -80,6 +81,20 @@ func golatest() *versions.GoLatest {
 }
 
 func main() {
+	// report panic to rollbar
+	defer func() {
+		rec := recover()
+		if rec != nil {
+			log.Errorf("Agent Crashed!: %s", rec)
+			debug.PrintStack()
+			if !metavars.ReportDisabled {
+				rollbar.Error(rollbar.ERR, fmt.Errorf("%s", rec))
+				rollbar.Wait()
+			}
+		}
+		os.Exit(1)
+	}()
+
 	cli.VersionPrinter = func(c *cli.Context) {
 		b, _ := json.MarshalIndent(golatest(), "", "  ")
 		fmt.Println(string(b))
@@ -106,8 +121,8 @@ func main() {
 			Usage: "set `Provider`",
 		},
 		cli.BoolFlag{
-			Name:  "enablereport, R",
-			Usage: "Send crash report to rollbar.",
+			Name:  "disablereport, N",
+			Usage: "Do not send crash report to rollbar.",
 		},
 	}
 

--- a/metavars/vars.go
+++ b/metavars/vars.go
@@ -7,8 +7,8 @@ var (
 	// such as Instance ID.
 	ServerID string
 
-	// ReportEnabled  true => send error report to rollbar
-	ReportEnabled bool
+	// ReportDisabled  true => do not send error report to rollbar
+	ReportDisabled bool
 
 	// AgentID is unique identifer of alm-agent
 	AgentID string


### PR DESCRIPTION
副作用でcli.NewExitErrorのステータス(int)が効かなくなるけど、まあよいです。