### PR TITLE
Change ssh path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,10 +20,10 @@
   version = "v1.0.3"
 
 [[projects]]
+  branch = "master"
   name = "github.com/aws/aws-sdk-go"
   packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/autoscaling","service/cloudformation","service/elb","service/sts"]
-  revision = "2dd0010a66ff968eb03c2507cfb5deab080c5d93"
-  version = "v1.10.37"
+  revision = "00b2e557c43c3637d4e2282f88a9cf3fd070ff89"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -175,6 +175,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b3e9b7600e9bf7361f1d3af5b0eff63cf29a700583ef71b1e6d0c154455c6c5a"
+  inputs-digest = "bfa2150dc5f6400666461a51837e78890b22c19fc8d23bc8e4176362fe4ff8b6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/aws/aws-sdk-go/aws/..."
+  name = "github.com/aws/aws-sdk-go"
 
 [[constraint]]
   name = "github.com/docker/docker"

--- a/code/code.go
+++ b/code/code.go
@@ -143,7 +143,7 @@ var (
 func createIdentityFile(key string) error {
 	log.Debug("Step: createIdentityFile")
 	if !util.FileExists(sshDir) {
-		if err := os.Mkdir(sshDir, 0700); err != nil {
+		if err := os.MkdirAll(sshDir, 0700); err != nil {
 			return err
 		}
 	}

--- a/code/code.go
+++ b/code/code.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"time"
@@ -69,14 +69,14 @@ func (c *Code) CheckUpdate() (bool, error) {
 
 	if len(dirs) > 10 {
 		for _, dir := range dirs[10:] {
-			err := os.RemoveAll(path.Join(base, dir.Name()))
+			err := os.RemoveAll(filepath.Join(base, dir.Name()))
 			if err != nil {
 				return false, err
 			}
 		}
 	}
 
-	c.Path = path.Join(base, dirs[0].Name())
+	c.Path = filepath.Join(base, dirs[0].Name())
 	g := &Git{
 		url:  c.URL,
 		path: c.Path,
@@ -87,7 +87,7 @@ func (c *Code) CheckUpdate() (bool, error) {
 }
 
 func (c *Code) Get() (string, error) {
-	baseDir := path.Join("/srv", "code")
+	baseDir := filepath.Join("/srv", "code")
 	if !util.FileExists(baseDir) {
 		if err := os.MkdirAll(baseDir, 0755); err != nil {
 			return "", err
@@ -97,7 +97,7 @@ func (c *Code) Get() (string, error) {
 	t := time.Now().Format("20060102150405")
 	g := &Git{
 		url:  c.URL,
-		path: path.Join(baseDir, t),
+		path: filepath.Join(baseDir, t),
 		ref:  c.Ref,
 	}
 	err := g.get()
@@ -148,12 +148,7 @@ func createIdentityFile(key string) error {
 		}
 	}
 
-	sshKey := path.Join(sshDir, sshKeyName)
-	if util.FileExists(sshKey) {
-		if err := os.Remove(sshKey); err != nil {
-			return err
-		}
-	}
+	sshKey := filepath.Join(sshDir, sshKeyName)
 
 	log.Debugf("Create IdentityFile %s", sshKey)
 	err := ioutil.WriteFile(sshKey, []byte(key), 0600)
@@ -233,8 +228,8 @@ exec ssh -i %s "$@"
 		}
 	}
 
-	s := fmt.Sprintf(c, path.Join(sshDir, sshKeyName))
-	err := ioutil.WriteFile(script, []byte(s), 0700)
+	s := fmt.Sprintf(c, filepath.Join(sshDir, sshKeyName))
+	err := ioutil.WriteFile(filepath.Join(sshDir, gitSshScriptName), []byte(s), 0700)
 	if err != nil {
 		return err
 	}

--- a/code/code.go
+++ b/code/code.go
@@ -220,13 +220,6 @@ func writeGitSshScript() error {
 	c := `#!/bin/sh
 exec ssh -i %s "$@"
 `
-	script := path.Join(sshDir, gitSshScriptName)
-
-	if util.FileExists(script) {
-		if err := os.Remove(script); err != nil {
-			return err
-		}
-	}
 
 	s := fmt.Sprintf(c, filepath.Join(sshDir, sshKeyName))
 	err := ioutil.WriteFile(filepath.Join(sshDir, gitSshScriptName), []byte(s), 0700)

--- a/code/code.go
+++ b/code/code.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -136,7 +135,7 @@ func (c *Code) PrivateRepo() error {
 
 	if url.Scheme == "git" && url.Host == "github.com" {
 		c.URL = convertGithubGitURLToSSH(url)
-		log.Debugf("Converted URL is %s.", c.URL)
+		log.Debugf("Converted URL is %s", c.URL)
 	}
 
 	err = checkKnownHosts(url)
@@ -194,9 +193,9 @@ func convertGithubGitURLToSSH(url *url.URL) string {
 
 func checkKnownHosts(url *url.URL) error {
 	log.Debug("Step: checkKnownHosts")
-	out, err := exec.Command("ssh-keygen", "-F", url.Host, "-f", knownHosts).Output()
+	out, err := util.Executer.Exec("ssh-keygen", "-F", url.Host, "-f", knownHosts)
 	if string(out) == "" && err != nil {
-		out, err = exec.Command("ssh-keyscan", url.Host).Output()
+		out, err := util.Executer.Exec("ssh-keyscan", url.Host)
 		if err != nil {
 			return err
 		}
@@ -222,7 +221,6 @@ func writeGitSshScript() error {
 	c := `#!/bin/sh
 exec ssh -i %s "$@"
 `
-
 	s := fmt.Sprintf(c, filepath.Join(sshDir, sshKeyName))
 	err := ioutil.WriteFile(filepath.Join(sshDir, gitSshScriptName), []byte(s), 0700)
 	if err != nil {

--- a/code/code.go
+++ b/code/code.go
@@ -17,6 +17,25 @@ import (
 	"github.com/mobingi/alm-agent/util"
 )
 
+var (
+	knownHosts       = "/etc/ssh/ssh_known_hosts"
+	sshDir           = "/opt/mobingi/etc/ssh"
+	sshKeyName       = "id_alm_agent"
+	gitSshScriptName = "git_ssh.sh"
+)
+
+// ref. `man git-clone`
+// The following syntaxes may be used.
+// - ssh://[user@]host.xz[:port]/path/to/repo.git/
+// - git://host.xz[:port]/path/to/repo.git/
+// - http[s]://host.xz[:port]/path/to/repo.git/
+// - ftp[s]://host.xz[:port]/path/to/repo.git/
+// - [user@]host.xz:path/to/repo.git/
+var (
+	hasSchemeSyntax = regexp.MustCompile("^[^:]+://")
+	scpLikeSyntax   = regexp.MustCompile("^([^@]+@)?([^:]+):/?(.+)$")
+)
+
 type Code struct {
 	URL  string
 	Ref  string
@@ -133,13 +152,6 @@ func (c *Code) PrivateRepo() error {
 	return nil
 }
 
-var (
-	knownHosts       = "/etc/ssh/ssh_known_hosts"
-	sshDir           = "/opt/mobingi/etc/ssh"
-	sshKeyName       = "id_alm_agent"
-	gitSshScriptName = "git_ssh.sh"
-)
-
 func createIdentityFile(key string) error {
 	log.Debug("Step: createIdentityFile")
 	if !util.FileExists(sshDir) {
@@ -157,16 +169,6 @@ func createIdentityFile(key string) error {
 	}
 	return nil
 }
-
-// ref. `man git-clone`
-// The following syntaxes may be used.
-// - ssh://[user@]host.xz[:port]/path/to/repo.git/
-// - git://host.xz[:port]/path/to/repo.git/
-// - http[s]://host.xz[:port]/path/to/repo.git/
-// - ftp[s]://host.xz[:port]/path/to/repo.git/
-// - [user@]host.xz:path/to/repo.git/
-var hasSchemeSyntax = regexp.MustCompile("^[^:]+://")
-var scpLikeSyntax = regexp.MustCompile("^([^@]+@)?([^:]+):/?(.+)$")
 
 func parseURL(rawURL string) (*url.URL, error) {
 	log.Debug("Step: parseURL")

--- a/code/git.go
+++ b/code/git.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strings"
 
@@ -66,13 +67,15 @@ func (g *Git) checkUpdate() (bool, error) {
 func (g *Git) get() error {
 	if isTag.MatchString(g.ref) {
 		log.Infof("Executing git clone %s %s", g.url, g.path)
-		out, err := exec.Command("git", "clone", g.url, g.path).CombinedOutput()
+		cmd := exec.Command("git", "clone", g.url, g.path)
+		cmd.Env = append(os.Environ(), "GIT_SSH="+path.Join(sshDir, gitSshScriptName))
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Error(string(out))
 		}
 
 		log.Infof("Executing git checkout %s ", g.ref)
-		cmd := exec.Command("git", "checkout", g.ref)
+		cmd = exec.Command("git", "checkout", g.ref)
 		cmd.Dir = g.path
 		err = cmd.Run()
 		if err != nil {
@@ -81,7 +84,9 @@ func (g *Git) get() error {
 		return err
 	} else {
 		log.Infof("Executing git clone -b %s %s %s", g.ref, g.url, g.path)
-		out, err := exec.Command("git", "clone", "-b", g.ref, g.url, g.path).CombinedOutput()
+		cmd := exec.Command("git", "clone", "-b", g.ref, g.url, g.path)
+		cmd.Env = append(os.Environ(), "GIT_SSH="+path.Join(sshDir, gitSshScriptName))
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Error(string(out))
 		}

--- a/util/executer.go
+++ b/util/executer.go
@@ -8,7 +8,13 @@ import (
 // ExecuterInterface has Exec to wrap os commands.
 type ExecuterInterface interface {
 	Exec(cmd string, args ...string) ([]byte, error)
-	ExecWithOpts(workdir string, env []string, cmd string, args ...string) ([]byte, error)
+	ExecWithOpts(execopts *ExecOpts, cmd string, args ...string) ([]byte, error)
+}
+
+// ExecOpts is options for ExecWithOpts
+type ExecOpts struct {
+	Dir string
+	Env []string
 }
 
 type osExecuter struct{}
@@ -26,10 +32,10 @@ func (o *osExecuter) Exec(command string, args ...string) ([]byte, error) {
 	return out, err
 }
 
-func (o *osExecuter) ExecWithOpts(dir string, env []string, command string, args ...string) ([]byte, error) {
+func (o *osExecuter) ExecWithOpts(opts *ExecOpts, command string, args ...string) ([]byte, error) {
 	cmd := exec.Command(command, args...)
-	cmd.Dir = dir
-	cmd.Env = env
+	cmd.Dir = opts.Dir
+	cmd.Env = opts.Env
 	out, err := cmd.CombinedOutput()
 	return out, err
 }
@@ -49,11 +55,11 @@ func (m *MockExecuter) Exec(command string, args ...string) ([]byte, error) {
 }
 
 // ExecWithOpts returns command + args and put these to StdOut.
-func (m *MockExecuter) ExecWithOpts(dir string, env []string, command string, args ...string) ([]byte, error) {
+func (m *MockExecuter) ExecWithOpts(opts *ExecOpts, command string, args ...string) ([]byte, error) {
 	cl := command + " " + strings.Join(args, " ")
 	MockBuffer = append(MockBuffer, cl)
-	MockBuffer = append(MockBuffer, dir)
-	MockBuffer = append(MockBuffer, strings.Join(env, ","))
+	MockBuffer = append(MockBuffer, opts.Dir)
+	MockBuffer = append(MockBuffer, strings.Join(opts.Env, ","))
 	out := []byte(cl)
 	return out, nil
 }

--- a/util/executer.go
+++ b/util/executer.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -35,7 +36,7 @@ func (o *osExecuter) Exec(command string, args ...string) ([]byte, error) {
 func (o *osExecuter) ExecWithOpts(opts *ExecOpts, command string, args ...string) ([]byte, error) {
 	cmd := exec.Command(command, args...)
 	cmd.Dir = opts.Dir
-	cmd.Env = opts.Env
+	cmd.Env = append(os.Environ(), opts.Env...)
 	out, err := cmd.CombinedOutput()
 	return out, err
 }

--- a/util/executer_test.go
+++ b/util/executer_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +20,21 @@ func TestRealExec(t *testing.T) {
 	}
 
 	assert.Equal(string(out), expected)
+}
+func TestRealExecWithOpts(t *testing.T) {
+	defer ClearMockBuffer()
+	tmpDir, _ := ioutil.TempDir("", "exec")
+	defer os.RemoveAll(tmpDir)
+
+	assert := assert.New(t)
+
+	out, err := Executer.ExecWithOpts(tmpDir, []string{}, "pwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// `/private/` hides from shell on macos.
+	assert.Contains(string(out), tmpDir)
 }
 
 func TestMockExec(t *testing.T) {
@@ -40,9 +57,25 @@ func TestMockedExecuter(t *testing.T) {
 	assert := assert.New(t)
 
 	Executer = &MockExecuter{}
+
 	Executer.Exec("echo", "-n", "Mocked")
 	Executer.Exec("/bin/true", "but", "Mocked")
 
 	assert.Equal(MockBuffer[0], "echo -n Mocked")
 	assert.Equal(MockBuffer[1], "/bin/true but Mocked")
+}
+
+func TestMockedExecuterWithOpts(t *testing.T) {
+	defer ClearMockBuffer()
+
+	assert := assert.New(t)
+
+	Executer = &MockExecuter{}
+
+	env := []string{"a=1", "b=2"}
+	Executer.ExecWithOpts("/tmp", env, "echo", "-n", "Mocked")
+
+	assert.Equal(MockBuffer[0], "echo -n Mocked")
+	assert.Equal(MockBuffer[1], "/tmp")
+	assert.Equal(MockBuffer[2], "a=1,b=2")
 }

--- a/util/executer_test.go
+++ b/util/executer_test.go
@@ -28,7 +28,10 @@ func TestRealExecWithOpts(t *testing.T) {
 
 	assert := assert.New(t)
 
-	out, err := Executer.ExecWithOpts(tmpDir, []string{}, "pwd")
+	opts := &ExecOpts{
+		Dir: tmpDir,
+	}
+	out, err := Executer.ExecWithOpts(opts, "pwd")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +76,12 @@ func TestMockedExecuterWithOpts(t *testing.T) {
 	Executer = &MockExecuter{}
 
 	env := []string{"a=1", "b=2"}
-	Executer.ExecWithOpts("/tmp", env, "echo", "-n", "Mocked")
+	opts := &ExecOpts{
+		Dir: "/tmp",
+		Env: env,
+	}
+
+	Executer.ExecWithOpts(opts, "echo", "-n", "Mocked")
 
 	assert.Equal(MockBuffer[0], "echo -n Mocked")
 	assert.Equal(MockBuffer[1], "/tmp")


### PR DESCRIPTION
I propose two points below.

1. Change ssh path.
2. do not use ssh config file, use `GIT_SSH`.


### Now:
- `/etc/ssh/ssh_known_hosts`
  - used when `alm-agent register`
- `/root/.ssh/id_code`
  - for git private key
- `/root/.ssh/known_hosts`
  - used when If there is a new host
- `/root/.ssh/config`
  - used when If there is a new host

### Proposal:
- `/etc/ssh/ssh_known_hosts` -> no change
- `/root/.ssh/id_code` -> `/opt/mobingi/etc/ssh/id_alm_agent`
- `/root/.ssh/known_hosts` -> `/etc/ssh/ssh_known_hosts`
- `/root/.ssh/config` -> do not use config, use `GIT_SSH`.
  - `GIT_SSH` script path is `/opt/mobingi/etc/ssh/git_ssh.sh`.
