### PR TITLE
Reduce access token request

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mobingi/alm-agent/config"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -30,6 +30,8 @@ type clientInterface interface {
 type apiToken struct {
 	TokenType string `json:"token_type"`
 	Token     string `json:"access_token"`
+	ExpiresIn int64  `json:"expires_in"`
+	ExpiresAt int64  `json:"expires_at"`
 }
 
 // StsToken for CWLogs

--- a/api/request.go
+++ b/api/request.go
@@ -45,7 +45,7 @@ var RoutesV3 = &route{
 	LogsSTS:           "/v3/alm/agent/logs_access_token",
 }
 
-var tokentCachePath = "/opt/mobingi/etc/tokencache.json"
+var tokenCachePath = "/opt/mobingi/etc/tokencache.json"
 
 // GetAccessToken requests token of user for auth by API.
 func GetAccessToken() error {
@@ -72,19 +72,19 @@ func GetAccessToken() error {
 func createAccessTokenCache() {
 	apitoken.ExpiresAt = time.Now().Unix() + apitoken.ExpiresIn
 	at, _ := json.Marshal(apitoken)
-	ioutil.WriteFile(tokentCachePath, []byte(at), 0600)
+	ioutil.WriteFile(tokenCachePath, []byte(at), 0600)
 	return
 }
 
 func flushAccessTokenCache() {
-	if util.FileExists(tokentCachePath) {
-		os.Remove(tokentCachePath)
+	if util.FileExists(tokenCachePath) {
+		os.Remove(tokenCachePath)
 	}
 	return
 }
 
 func fetchAccessTokenCache() error {
-	at, err := ioutil.ReadFile(tokentCachePath)
+	at, err := ioutil.ReadFile(tokenCachePath)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"runtime/debug"
 	"sort"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -64,6 +66,12 @@ func beforeActions(c *cli.Context) error {
 		versions.AutoUpdate(golatest())
 	}
 	log.Debugf("Set provider to %#v", c.GlobalString("provider"))
+
+	rand.Seed(int64(os.Getpid()))
+
+	splay := rand.Intn(3000)
+	log.Debugf("Wait %d milliseconds...", splay)
+	time.Sleep(time.Duration(splay) * time.Millisecond)
 	return nil
 }
 


### PR DESCRIPTION
- 実行直後に 0 - 3000msでrandom waitする.
- API の access_token (12h有効) を 7h だけローカルファイルとして cache する。