### PR TITLE
Trace docker run outputs to share with awslogs-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ setup:
 deps:
 	dep ensure -v
 
-.PHONY: bindata
 bindata:
 	tomlv _data/*.toml
 	go-assets-builder --package=bindata --output=./bindata/bindata.go _data
@@ -64,3 +63,5 @@ list:
 
 version:
 	@echo ${VERSION}.${MINOR_VERSION}
+
+.PHONY: setup deps bindata verifydata test race lint fmt build cibuild clean addon list version

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ clean:
 
 addon:
 	cd addons/aws/; go build -ldflags "$(LDFLAGS)" -o ../../bin/$(NAME)-addon-aws
+	cd addons/common_logtracer/; go build -ldflags "$(LDFLAGS)" -o ../../bin/alm-logtracer
 
 list:
 	@ls -1 bin

--- a/addons/common_logtracer/main.go
+++ b/addons/common_logtracer/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	docker "docker.io/go-docker"
@@ -35,7 +39,7 @@ func main() {
 		}
 
 		// check existance
-		_, err = cli.ContainerInspect(ctxWithTO, ctid)
+		c, err := cli.ContainerInspect(ctxWithTO, ctid)
 		if err != nil {
 			fmt.Printf("%s\n is not found. bye!", ctid)
 			os.Exit(int(1))
@@ -50,6 +54,7 @@ func main() {
 			Tail:       "all",
 		}
 		responseBody, err := cli.ContainerLogs(ctx, ctid, options)
+		defer responseBody.Close()
 
 		go func() {
 			logfile := logDirPath + fmt.Sprintf("dockerrun.%s.log", ctid)
@@ -58,7 +63,11 @@ func main() {
 				panic(err)
 			}
 			defer dst.Close()
-			io.Copy(dst, responseBody)
+			if c.Config.Tty {
+				io.Copy(dst, responseBody)
+			} else {
+				StdCopy(dst, dst, responseBody)
+			}
 		}()
 
 		ctxBG := context.Background()
@@ -76,4 +85,186 @@ func main() {
 		}
 	}
 	os.Exit(0)
+}
+
+// docker-ce/components/engine/pkg/stdcopy/stdcopy.go
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+	// Systemerr represents errors originating from the system that make it
+	// into the the multiplexed stream.
+	Systemerr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It inserts the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(p []byte) (n int, err error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err = w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		stream := StdType(buf[stdWriterFdIndex])
+		// Check the first byte to know where to write
+		switch stream {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		case Systemerr:
+			// If we're on Systemerr, we won't write anywhere.
+			// NB: if this code changes later, make sure you don't try to write
+			// to outstream if Systemerr is the stream
+			out = nil
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// we might have an error from the source mixed up in our multiplexed
+		// stream. if we do, return it.
+		if stream == Systemerr {
+			return written, fmt.Errorf("error from daemon in stream: %s", string(buf[stdWriterPrefixLen:frameSize+stdWriterPrefixLen]))
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if ew != nil {
+			return 0, ew
+		}
+
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
 }

--- a/addons/common_logtracer/main.go
+++ b/addons/common_logtracer/main.go
@@ -57,7 +57,7 @@ func main() {
 		defer responseBody.Close()
 
 		go func() {
-			logfile := logDirPath + fmt.Sprintf("dockerrun.%s.log", ctid)
+			logfile := logDirPath + "dockerrun.active.log"
 			dst, err := os.Create(logfile)
 			if err != nil {
 				panic(err)

--- a/addons/common_logtracer/main.go
+++ b/addons/common_logtracer/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	docker "docker.io/go-docker"
+	"docker.io/go-docker/api/types"
+)
+
+var logDirPath = "/var/log/alm-agent/container/log/"
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println("Please pass container id as 1st arg, bye.")
+		os.Exit(int(0))
+	} else if len(os.Args) == 2 {
+		// exec itself
+		cmd := exec.Command(os.Args[0], "--child", os.Args[1])
+		cmd.Start()
+	} else {
+		// run like daemon
+		var ctid = os.Args[2]
+		ctxWithTO, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		cli, err := docker.NewEnvClient()
+		if err != nil {
+			panic(err)
+		}
+
+		// check existance
+		_, err = cli.ContainerInspect(ctxWithTO, ctid)
+		if err != nil {
+			fmt.Printf("%s\n is not found. bye!", ctid)
+			os.Exit(int(1))
+		}
+
+		ctx := context.Background()
+
+		options := types.ContainerLogsOptions{
+			ShowStdout: true,
+			ShowStderr: true,
+			Follow:     true,
+			Tail:       "all",
+		}
+		responseBody, err := cli.ContainerLogs(ctx, ctid, options)
+
+		go func() {
+			logfile := logDirPath + fmt.Sprintf("dockerrun.%s.log", ctid)
+			dst, err := os.Create(logfile)
+			if err != nil {
+				panic(err)
+			}
+			defer dst.Close()
+			io.Copy(dst, responseBody)
+		}()
+
+		ctxBG := context.Background()
+		wch, errC := cli.ContainerWait(ctxBG, ctid, "")
+
+		go func() {
+			for {
+				a := <-wch
+				os.Exit(int(a.StatusCode))
+			}
+		}()
+
+		if err := <-errC; err != nil {
+			log.Fatal(err)
+		}
+	}
+	os.Exit(0)
+}

--- a/api/local_test.go
+++ b/api/local_test.go
@@ -35,7 +35,7 @@ func TestWriteTempToken(t *testing.T) {
 	assert.Contains(string(buf), "STSTOKENXXX")
 }
 
-func TestFetServerConfigFromFile(t *testing.T) {
+func TestGetServerConfigFromFile(t *testing.T) {
 	assert := assert.New(t)
 	sc := &serverConfig.Config{}
 	getServerConfigFromFile("../test/fixtures/serverconfig.v2.json", sc)

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -23,6 +23,7 @@ func mockPost(fn func(path string, values url.Values, target interface{}) error)
 
 func TestGetAccessToken(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
+	flushAccessTokenCache()
 	var apitoken = &apiToken{}
 	tc := &config.Config{
 		APIHost:            "https://test.example.com",
@@ -67,6 +68,7 @@ func TestGetAccessToken(t *testing.T) {
 }
 
 func TestGetSTSToken(t *testing.T) {
+	flushAccessTokenCache()
 	log.SetLevel(log.DebugLevel)
 	var testtoken = &StsToken{}
 	tc := &config.Config{

--- a/api/request_test.go
+++ b/api/request_test.go
@@ -24,6 +24,7 @@ func mockPost(fn func(path string, values url.Values, target interface{}) error)
 func TestGetAccessToken(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	flushAccessTokenCache()
+	defer flushAccessTokenCache()
 	var apitoken = &apiToken{}
 	tc := &config.Config{
 		APIHost:            "https://test.example.com",
@@ -69,6 +70,7 @@ func TestGetAccessToken(t *testing.T) {
 
 func TestGetSTSToken(t *testing.T) {
 	flushAccessTokenCache()
+	defer flushAccessTokenCache()
 	log.SetLevel(log.DebugLevel)
 	var testtoken = &StsToken{}
 	tc := &config.Config{

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -17,6 +20,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
+
+func tracerPath() string {
+	selfPath, _ := os.Executable()
+	d, _ := filepath.Split(selfPath)
+	tracerPath := filepath.Join(d, "alm-logtracer")
+	return tracerPath
+}
 
 // Ensure start or replace container with newest config
 func Ensure(c *cli.Context) error {
@@ -289,6 +299,10 @@ func Ensure(c *cli.Context) error {
 		newContainer, err := d.StartContainer("standby", codeDir)
 		if err != nil {
 			return cli.NewExitError(err, 1)
+		}
+
+		if util.FileExists(tracerPath()) {
+			exec.Command(tracerPath(), newContainer.ID).Start()
 		}
 
 		d.UnmapPort()

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -228,6 +228,10 @@ func Ensure(c *cli.Context) error {
 		}
 		log.Debugf("%#v", newContainer)
 
+		if util.FileExists(tracerPath()) {
+			exec.Command(tracerPath(), newContainer.ID).Start()
+		}
+
 		log.Debug("Step: d.MapPort")
 		err = d.MapPort(newContainer)
 		if err != nil {

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -305,10 +305,6 @@ func Ensure(c *cli.Context) error {
 			return cli.NewExitError(err, 1)
 		}
 
-		if util.FileExists(tracerPath()) {
-			exec.Command(tracerPath(), newContainer.ID).Start()
-		}
-
 		d.UnmapPort()
 		d.MapPort(newContainer)
 
@@ -322,6 +318,10 @@ func Ensure(c *cli.Context) error {
 		}
 
 		d.RenameContainer(newContainer, "active")
+
+		if util.FileExists(tracerPath()) {
+			exec.Command(tracerPath(), newContainer.ID).Start()
+		}
 	}
 
 	log.Debug("Step: serverConfig.WriteUpdated")


### PR DESCRIPTION
changes

- new binary `alm-logtracer`
  - run like daemon (detouched process)
  - capture docker run outputs and puts to `/var/log/alm-agent/container/log/dockerrun.{container.ID}.log`
- run `alm-logtracer` after launch new user container.