### PR TITLE
Checkout code to another dir

### DIFF
--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -245,7 +245,6 @@ func Ensure(c *cli.Context) error {
 		}
 
 		codeDir := ""
-		codeUpdated := false
 		if s.GitRepo != "" {
 			code := code.New(s)
 			if code.Key != "" {
@@ -255,20 +254,13 @@ func Ensure(c *cli.Context) error {
 				}
 			}
 
-			codeUpdated, err = code.CheckUpdate()
+			codeDir, err = code.Get()
 			if err != nil {
 				return cli.NewExitError(err, 1)
 			}
-
-			if codeUpdated {
-				codeDir, err = code.Get()
-				if err != nil {
-					return cli.NewExitError(err, 1)
-				}
-			} else {
-				codeDir = code.Path
-			}
 		}
+
+		log.Debugf("CodeDir is %s", codeDir)
 
 		api.SendContainerStatus("updating")
 		if oldContainer != nil {

--- a/code/code.go
+++ b/code/code.go
@@ -137,8 +137,8 @@ func (c *Code) cleanupReleases() error {
 	fmt.Println(dirs)
 	sort.Sort(ReleaseDirs(dirs))
 
-	if len(dirs) > 10 {
-		for _, dir := range dirs[10:] {
+	if len(dirs) > 5 {
+		for _, dir := range dirs[5:] {
 			delDirPath := filepath.Join(releaseDir, dir.Name())
 			log.Infof("Cleaning up old release... %s", delDirPath)
 			err := os.RemoveAll(delDirPath)

--- a/code/code.go
+++ b/code/code.go
@@ -41,12 +41,11 @@ var releaseDir = filepath.Join(baseDir, "releases")
 
 // Code is application repository
 type Code struct {
-	URL           string
-	Ref           string
-	Path          string
-	Key           string
-	LatestRelease string
-	Updated       bool
+	URL     string
+	Ref     string
+	Path    string
+	Key     string
+	Updated bool
 }
 
 // Release is exported code

--- a/code/code.go
+++ b/code/code.go
@@ -43,6 +43,8 @@ type Code struct {
 	Key  string
 }
 
+var baseDir = "/srv/code"
+
 // Dirs are directories under /srv/code
 type Dirs []os.FileInfo
 
@@ -72,12 +74,11 @@ func New(s *serverConfig.Config) *Code {
 
 // CheckUpdate checks code and cleans up old releases
 func (c *Code) CheckUpdate() (bool, error) {
-	base := "/srv/code"
-	if !util.FileExists(base) {
+	if !util.FileExists(baseDir) {
 		return true, nil
 	}
 
-	dirs, err := ioutil.ReadDir(base)
+	dirs, err := ioutil.ReadDir(baseDir)
 
 	if err != nil {
 		return false, err
@@ -91,14 +92,14 @@ func (c *Code) CheckUpdate() (bool, error) {
 
 	if len(dirs) > 10 {
 		for _, dir := range dirs[10:] {
-			err := os.RemoveAll(filepath.Join(base, dir.Name()))
+			err := os.RemoveAll(filepath.Join(baseDir, dir.Name()))
 			if err != nil {
 				return false, err
 			}
 		}
 	}
 
-	c.Path = filepath.Join(base, dirs[0].Name())
+	c.Path = filepath.Join(baseDir, dirs[0].Name())
 	g := &Git{
 		url:  c.URL,
 		path: c.Path,
@@ -111,7 +112,6 @@ func (c *Code) CheckUpdate() (bool, error) {
 // Get creates releases
 // returns code dirpash to mount by container.
 func (c *Code) Get() (string, error) {
-	baseDir := filepath.Join("/srv", "code")
 	if !util.FileExists(baseDir) {
 		if err := os.MkdirAll(baseDir, 0755); err != nil {
 			return "", err

--- a/code/code.go
+++ b/code/code.go
@@ -85,27 +85,6 @@ func (r *Release) putAsCurrent() {
 	ioutil.WriteFile(filepath.Join(baseDir, "current"), []byte(releaseInfo), 0644)
 }
 
-// ReleaseDirs are directories under /srv/code/releases
-type ReleaseDirs []os.FileInfo
-
-// Len to use ReleaseDirs as sort Interface.
-// do not remove
-func (d ReleaseDirs) Len() int {
-	return len(d)
-}
-
-// Swap to use ReleaseDirs as sort Interface.
-// do not remove
-func (d ReleaseDirs) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-
-// Less to use ReleaseDirs as sort Interface.
-// do not remove
-func (d ReleaseDirs) Less(i, j int) bool {
-	return d[j].ModTime().Unix() < d[i].ModTime().Unix()
-}
-
 // New creates New Code obj
 func New(s *serverConfig.Config) *Code {
 	ref := s.GitReference
@@ -119,7 +98,6 @@ func New(s *serverConfig.Config) *Code {
 	}
 }
 
-// CheckUpdate checks code and cleans up old releases
 func (c *Code) cleanupReleases() error {
 	if !util.FileExists(releaseDir) {
 		return nil
@@ -134,8 +112,9 @@ func (c *Code) cleanupReleases() error {
 		return nil
 	}
 
-	fmt.Println(dirs)
-	sort.Sort(ReleaseDirs(dirs))
+	sort.Slice(dirs, func(i, j int) bool {
+		return dirs[j].ModTime().Unix() < dirs[i].ModTime().Unix()
+	})
 
 	if len(dirs) > 5 {
 		for _, dir := range dirs[5:] {

--- a/code/git.go
+++ b/code/git.go
@@ -23,7 +23,8 @@ type Git struct {
 var isTag = regexp.MustCompile("^refs/tags/")
 
 func (g *Git) checkUpdate() (bool, error) {
-	out, err := execPipeline(
+	// same as `git remote get-url origin`.  but older git not support get-url.
+	rawRemoteURL, err := execPipeline(
 		g.path,
 		[]string{"git", "remote", "-v"},
 		[]string{"grep", "fetch"},
@@ -34,8 +35,8 @@ func (g *Git) checkUpdate() (bool, error) {
 		return false, err
 	}
 
-	url := strings.Trim(string(out), "\n")
-	if url != g.url {
+	remoteURL := strings.Trim(string(rawRemoteURL), "\n")
+	if remoteURL != g.url {
 		return true, nil
 	}
 
@@ -43,7 +44,11 @@ func (g *Git) checkUpdate() (bool, error) {
 	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSSHScriptName)}
 	opts.Dir = g.path
 
-	out, err = util.Executor.ExecWithOpts(opts, "git", "fetch")
+	out, err := util.Executor.ExecWithOpts(opts, "git", "fetch", "--prune")
+	if err != nil {
+		log.Error(string(out))
+	}
+	out, err = util.Executor.ExecWithOpts(opts, "git", "fetch", "--tags")
 	if err != nil {
 		log.Error(string(out))
 	}
@@ -64,32 +69,112 @@ func (g *Git) checkUpdate() (bool, error) {
 	return false, nil
 }
 
+func (g *Git) getRemoteCommitHash() (string, error) {
+	// git ls-remote origin master -q | cut -f 1
+	opts := &util.ExecOpts{}
+	opts.Dir = g.path
+
+	out, err := execPipeline(
+		g.path,
+		[]string{"git", "ls-remote", "origin", g.ref},
+		[]string{"cut", "-f", "1"},
+	)
+	if err != nil {
+		log.Error(string(out))
+		return "", err
+	}
+
+	return strings.Trim(string(out), "\n"), nil
+}
+
+func (g *Git) deepFetch(opts *util.ExecOpts) error {
+	// Fetch All
+	// git fetch --prune
+	// git tag -l | xargs git tag -d
+	// git fetch --tags
+	log.Debugf("Fetching remote %s", g.url)
+	out, err := util.Executor.ExecWithOpts(opts, "git", "fetch", "--prune")
+	if err != nil {
+		log.Error(string(out))
+		return err
+	}
+
+	_, err = execPipeline(
+		g.path,
+		[]string{"git", "tag", "-l"},
+		[]string{"xargs", "git", "tag", "-d"},
+	)
+	if err != nil {
+		log.Error(string(out))
+		return err
+	}
+
+	out, err = util.Executor.ExecWithOpts(opts, "git", "fetch", "--tags")
+	if err != nil {
+		log.Error(string(out))
+		return err
+	}
+	return nil
+}
+
 func (g *Git) get() error {
 	opts := &util.ExecOpts{}
 	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSSHScriptName)}
 
-	if isTag.MatchString(g.ref) {
+	// Initial Clone as Bare repo
+	if !util.FileExists(g.path) {
 		log.Infof("Executing git clone %s %s", g.url, g.path)
-		out, err := util.Executor.ExecWithOpts(opts, "git", "clone", g.url, g.path)
+		out, err := util.Executor.ExecWithOpts(opts, "git", "clone", "--bare", g.url, g.path)
 		if err != nil {
 			log.Error(string(out))
+			return err
 		}
-
-		log.Infof("Executing git checkout %s ", g.ref)
+	} else {
+		// Update Cached-Copy
 		opts.Dir = g.path
-		out, err = util.Executor.ExecWithOpts(opts, "git", "checkout", g.ref)
-		if err != nil {
-			log.Error(string(out))
-		}
+		g.deepFetch(opts)
+	}
+
+	// if isTag.MatchString(g.ref) {
+	// 	log.Infof("Executing git clone %s %s", g.url, g.path)
+	// 	out, err := util.Executor.ExecWithOpts(opts, "git", "clone", g.url, g.path)
+	// 	if err != nil {
+	// 		log.Error(string(out))
+	// 	}
+
+	// 	log.Infof("Executing git checkout %s ", g.ref)
+	// 	opts.Dir = g.path
+	// 	out, err = util.Executor.ExecWithOpts(opts, "git", "checkout", g.ref)
+	// 	if err != nil {
+	// 		log.Error(string(out))
+	// 	}
+	return nil
+	// log.Infof("Executing git clone -b %s %s %s", g.ref, g.url, g.path)
+	// out, err := util.Executor.ExecWithOpts(opts, "git", "clone", "-b", g.ref, g.url, g.path)
+	// if err != nil {
+	// 	log.Error(string(out))
+	// }
+}
+
+func (g *Git) release(hash, releasePath string) error {
+	if err := os.MkdirAll(releasePath, 0755); err != nil {
 		return err
 	}
 
-	log.Infof("Executing git clone -b %s %s %s", g.ref, g.url, g.path)
-	out, err := util.Executor.ExecWithOpts(opts, "git", "clone", "-b", g.ref, g.url, g.path)
+	// git archive --format=tar P{hash}} | tar -C {{releasePath} -xf -
+	out, err := execPipeline(
+		g.path,
+		[]string{"git", "archive", "--format=tar", hash},
+		[]string{"tar", "-C", releasePath, "-xf", "-"},
+	)
+
 	if err != nil {
 		log.Error(string(out))
+		return err
 	}
-	return err
+
+	log.Debug(out)
+	return nil
 }
 
 func execPipeline(dir string, commands ...[]string) ([]byte, error) {
@@ -97,6 +182,7 @@ func execPipeline(dir string, commands ...[]string) ([]byte, error) {
 	var err error
 
 	for i, c := range commands {
+		log.Debug(c)
 		cmds[i] = exec.Command(c[0], c[1:]...)
 		if dir != "" {
 			cmds[i].Dir = dir

--- a/code/git.go
+++ b/code/git.go
@@ -22,53 +22,6 @@ type Git struct {
 
 var isTag = regexp.MustCompile("^refs/tags/")
 
-func (g *Git) checkUpdate() (bool, error) {
-	// same as `git remote get-url origin`.  but older git not support get-url.
-	rawRemoteURL, err := execPipeline(
-		g.path,
-		[]string{"git", "remote", "-v"},
-		[]string{"grep", "fetch"},
-		[]string{"awk", "{print $2}"},
-	)
-
-	if err != nil {
-		return false, err
-	}
-
-	remoteURL := strings.Trim(string(rawRemoteURL), "\n")
-	if remoteURL != g.url {
-		return true, nil
-	}
-
-	opts := &util.ExecOpts{}
-	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSSHScriptName)}
-	opts.Dir = g.path
-
-	out, err := util.Executor.ExecWithOpts(opts, "git", "fetch", "--prune")
-	if err != nil {
-		log.Error(string(out))
-	}
-	out, err = util.Executor.ExecWithOpts(opts, "git", "fetch", "--tags")
-	if err != nil {
-		log.Error(string(out))
-	}
-
-	if isTag.MatchString(g.ref) {
-		out, err = util.Executor.ExecWithOpts(opts, "git", "diff", g.ref)
-	} else {
-		out, err = util.Executor.ExecWithOpts(opts, "git", "diff", fmt.Sprintf("origin/%s", g.ref))
-	}
-
-	if err != nil {
-		return false, err
-	}
-
-	if len(out) > 0 {
-		return true, nil
-	}
-	return false, nil
-}
-
 func (g *Git) getRemoteCommitHash() (string, error) {
 	// git ls-remote origin master -q | cut -f 1
 	opts := &util.ExecOpts{}
@@ -84,7 +37,12 @@ func (g *Git) getRemoteCommitHash() (string, error) {
 		return "", err
 	}
 
-	return strings.Trim(string(out), "\n"), nil
+	remoteHash := strings.Trim(string(out), "\n")
+	if remoteHash == "" {
+		return "", fmt.Errorf("git ref %s not found", g.ref)
+	}
+
+	return remoteHash, nil
 }
 
 func (g *Git) deepFetch(opts *util.ExecOpts) error {
@@ -135,25 +93,7 @@ func (g *Git) get() error {
 		g.deepFetch(opts)
 	}
 
-	// if isTag.MatchString(g.ref) {
-	// 	log.Infof("Executing git clone %s %s", g.url, g.path)
-	// 	out, err := util.Executor.ExecWithOpts(opts, "git", "clone", g.url, g.path)
-	// 	if err != nil {
-	// 		log.Error(string(out))
-	// 	}
-
-	// 	log.Infof("Executing git checkout %s ", g.ref)
-	// 	opts.Dir = g.path
-	// 	out, err = util.Executor.ExecWithOpts(opts, "git", "checkout", g.ref)
-	// 	if err != nil {
-	// 		log.Error(string(out))
-	// 	}
 	return nil
-	// log.Infof("Executing git clone -b %s %s %s", g.ref, g.url, g.path)
-	// out, err := util.Executor.ExecWithOpts(opts, "git", "clone", "-b", g.ref, g.url, g.path)
-	// if err != nil {
-	// 	log.Error(string(out))
-	// }
 }
 
 func (g *Git) release(hash, releasePath string) error {

--- a/code/git.go
+++ b/code/git.go
@@ -9,10 +9,11 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mobingi/alm-agent/util"
+	log "github.com/sirupsen/logrus"
 )
 
+// Git is wrapper of git command.
 type Git struct {
 	url  string
 	path string
@@ -39,7 +40,7 @@ func (g *Git) checkUpdate() (bool, error) {
 	}
 
 	opts := &util.ExecOpts{}
-	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSshScriptName)}
+	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSSHScriptName)}
 	opts.Dir = g.path
 
 	out, err = util.Executor.ExecWithOpts(opts, "git", "fetch")
@@ -59,14 +60,13 @@ func (g *Git) checkUpdate() (bool, error) {
 
 	if len(out) > 0 {
 		return true, nil
-	} else {
-		return false, nil
 	}
+	return false, nil
 }
 
 func (g *Git) get() error {
 	opts := &util.ExecOpts{}
-	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSshScriptName)}
+	opts.Env = []string{"GIT_SSH=" + filepath.Join(sshDir, gitSSHScriptName)}
 
 	if isTag.MatchString(g.ref) {
 		log.Infof("Executing git clone %s %s", g.url, g.path)
@@ -82,14 +82,14 @@ func (g *Git) get() error {
 			log.Error(string(out))
 		}
 		return err
-	} else {
-		log.Infof("Executing git clone -b %s %s %s", g.ref, g.url, g.path)
-		out, err := util.Executor.ExecWithOpts(opts, "git", "clone", "-b", g.ref, g.url, g.path)
-		if err != nil {
-			log.Error(string(out))
-		}
-		return err
 	}
+
+	log.Infof("Executing git clone -b %s %s %s", g.ref, g.url, g.path)
+	out, err := util.Executor.ExecWithOpts(opts, "git", "clone", "-b", g.ref, g.url, g.path)
+	if err != nil {
+		log.Error(string(out))
+	}
+	return err
 }
 
 func execPipeline(dir string, commands ...[]string) ([]byte, error) {

--- a/code/git_test.go
+++ b/code/git_test.go
@@ -1,0 +1,51 @@
+package code
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func Test_execPipeline(t *testing.T) {
+	tmpDir, _ := ioutil.TempDir("", "exec")
+	defer os.RemoveAll(tmpDir)
+
+	// Generate by VSCode plugin
+	type args struct {
+		dir      string
+		commands [][]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		// Testcases
+		{
+			name: "echo test",
+			args: args{
+				dir: tmpDir,
+				commands: [][]string{
+					[]string{"echo", "foobar"},
+					[]string{"grep", "foo"},
+				},
+			},
+			want:    []byte("foobar\n"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := execPipeline(tt.args.dir, tt.args.commands...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("execPipeline() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("execPipeline() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
changes

- [x] clone bare repo on local to keep as cache.
- [x] export via git archive to release dir
  - [x] support .gitattributes to exclude
- [x] mount release dir to ignore `./git`.
- [x] follow change origin url
- [x] remove older releases (>5)
