### PR TITLE
use cache for STS 20-29min

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,13 +34,6 @@ type apiToken struct {
 	ExpiresAt int64  `json:"expires_at"`
 }
 
-// StsToken for CWLogs
-type StsToken struct {
-	AccessKeyID     string
-	SecretAccessKey string
-	SessionToken    string
-}
-
 type client struct {
 	config *config.Config
 }

--- a/api/request.go
+++ b/api/request.go
@@ -143,15 +143,22 @@ func getServerConfigFromAPI(sc *serverConfig.Config) error {
 
 // GetStsToken to STS token for CWLogs
 func GetStsToken() (*StsToken, error) {
+	err := stsToken.fetchCache()
+	if err == nil {
+		return &stsToken, nil
+	}
+	log.Debug(err)
+
 	values := url.Values{}
 	values.Set("stack_id", c.getConfig().StackID)
 	values.Set("service", "logs")
 
-	err := Get(RoutesV3.Sts, values, &stsToken)
+	err = Get(RoutesV3.Sts, values, &stsToken)
 	if err != nil {
 		return nil, err
 	}
 
+	stsToken.createCache()
 	return &stsToken, nil
 }
 

--- a/api/sts_token.go
+++ b/api/sts_token.go
@@ -21,12 +21,12 @@ type StsToken struct {
 	SessionToken    string
 }
 
-// use Cache 40-55min randomly
+// use Cache 20-29min randomly
 func (sts *StsToken) fetchCache() error {
 	if util.FileExists(stsTokenCachePath) {
 		rand.Seed(time.Now().UnixNano())
 		t := time.Now()
-		it := 55 - rand.Intn(15)
+		it := 29 - rand.Intn(9)
 		at := t.Add(-(time.Duration(it) * time.Minute))
 
 		file, _ := os.Open(stsTokenCachePath)

--- a/api/sts_token.go
+++ b/api/sts_token.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/mobingi/alm-agent/util"
+	log "github.com/sirupsen/logrus"
+)
+
+var stsTokenCachePath = "/opt/mobingi/etc/sts_cache.json"
+
+// StsToken for grant access for AWS resources
+type StsToken struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+// use Cache 40-55min randomly
+func (sts *StsToken) fetchCache() error {
+	if util.FileExists(stsTokenCachePath) {
+		rand.Seed(time.Now().UnixNano())
+		t := time.Now()
+		it := 55 - rand.Intn(15)
+		at := t.Add(-(time.Duration(it) * time.Minute))
+
+		file, _ := os.Open(stsTokenCachePath)
+		defer file.Close()
+
+		info, _ := file.Stat()
+		if at.After(info.ModTime()) {
+			return errors.New("STS cache too old, will be renew")
+		}
+		log.Debug("use local cache of StsToken")
+		cache, _ := ioutil.ReadFile(stsTokenCachePath)
+		json.Unmarshal([]byte(cache), &sts)
+		return nil
+	}
+	return errors.New("no STS cache")
+}
+
+func (sts *StsToken) createCache() error {
+	token, _ := json.Marshal(sts)
+	ioutil.WriteFile(stsTokenCachePath, []byte(token), 0600)
+	return nil
+}
+
+func (sts *StsToken) flushCache() {
+	if util.FileExists(stsTokenCachePath) {
+		os.Remove(stsTokenCachePath)
+	}
+	return
+}

--- a/api/sts_token_test.go
+++ b/api/sts_token_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/mobingi/alm-agent/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func testCreateCache(t *testing.T) {
+	assert := assert.New(t)
+	stsToken := &StsToken{
+		AccessKeyID:     "testKEY",
+		SecretAccessKey: "testSKEY",
+		SessionToken:    "testTOKEN",
+	}
+	tmpCacheDir, _ := ioutil.TempDir("", "stsToken")
+	defer os.RemoveAll(tmpCacheDir)
+
+	origstsTokenCachePath := stsTokenCachePath
+	stsTokenCachePath = tmpCacheDir
+	defer func() { stsTokenCachePath = origstsTokenCachePath }()
+	stsToken.createCache()
+
+	assert.True(util.FileExists(stsTokenCachePath))
+}

--- a/api/sts_token_test.go
+++ b/api/sts_token_test.go
@@ -1,15 +1,18 @@
 package api
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/mobingi/alm-agent/util"
 	"github.com/stretchr/testify/assert"
 )
 
-func testCreateCache(t *testing.T) {
+func TestCreateCache(t *testing.T) {
 	assert := assert.New(t)
 	stsToken := &StsToken{
 		AccessKeyID:     "testKEY",
@@ -20,9 +23,49 @@ func testCreateCache(t *testing.T) {
 	defer os.RemoveAll(tmpCacheDir)
 
 	origstsTokenCachePath := stsTokenCachePath
-	stsTokenCachePath = tmpCacheDir
+	stsTokenCachePath = filepath.Join(tmpCacheDir, "sts_cache.json")
 	defer func() { stsTokenCachePath = origstsTokenCachePath }()
 	stsToken.createCache()
 
 	assert.True(util.FileExists(stsTokenCachePath))
+}
+
+func TestFetchCache(t *testing.T) {
+	assert := assert.New(t)
+	stsToken := &StsToken{
+		AccessKeyID:     "testKEY",
+		SecretAccessKey: "testSKEY",
+		SessionToken:    "testTOKEN",
+	}
+	tmpCacheDir, _ := ioutil.TempDir("", "stsToken")
+	defer os.RemoveAll(tmpCacheDir)
+
+	origstsTokenCachePath := stsTokenCachePath
+	stsTokenCachePath = filepath.Join(tmpCacheDir, "sts_cache.json")
+	defer func() { stsTokenCachePath = origstsTokenCachePath }()
+
+	err := stsToken.fetchCache()
+	if assert.Error(err) {
+		assert.Equal(errors.New("no STS cache"), err)
+	}
+
+	stsToken.createCache()
+
+	err = stsToken.fetchCache()
+	assert.Nil(err)
+
+	assert.Equal("testKEY", stsToken.AccessKeyID)
+	assert.Equal("testSKEY", stsToken.SecretAccessKey)
+	assert.Equal("testTOKEN", stsToken.SessionToken)
+
+	// refresh
+	now := time.Now()
+	atime := now.Add(-(time.Duration(30) * time.Minute))
+	mtime := now.Add(-(time.Duration(30) * time.Minute))
+	os.Chtimes(stsTokenCachePath, atime, mtime)
+
+	err = stsToken.fetchCache()
+	if assert.Error(err) {
+		assert.Equal(errors.New("STS cache too old, will be renew"), err)
+	}
 }


### PR DESCRIPTION
#55 でやりかけの実装。 別のアプローチにしてみました。

トークンの期限が60min? でawslogsコンテナのリロードが30分おきなので --

- とりあえずローカルファイルに書き出す
- last modが20-29分より
  - 新しければそれを使う
  - 古ければ取得しなおす

ただしこの実装上、20-29に綺麗には分布しません。20分こえたらじわじわと更新されます。