### PR TITLE
Fix panic when stop alm-agent

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -61,6 +61,6 @@ func Stop(c *cli.Context) error {
 		}
 	}
 
-	api.SendAgentStatus("stopped", err.Error())
+	api.SendAgentStatus("stopped", "")
 	return nil
 }


### PR DESCRIPTION
panic message:

```
## Message
runtime error: invalid memory address or nil pointer dereference

## Traceback
Traceback (most recent call last):
  File "github.com/mobingi/alm-agent/main.go", line 108, in main.main.func1
  File "/usr/local/go/src/runtime/asm_amd64.s", line 573, in runtime.call32
  File "/usr/local/go/src/runtime/panic.go", line 505, in runtime.gopanic
  File "/usr/local/go/src/runtime/panic.go", line 63, in runtime.panicmem
  File "/usr/local/go/src/runtime/signal_unix.go", line 388, in runtime.sigpanic
  File "github.com/mobingi/alm-agent/cmd/stop.go", line 64, in cmd.Stop
  File "github.com/mobingi/alm-agent/cmd/stop.go", line 57, in cmd.Stop
  File "github.com/mobingi/alm-agent/vendor/github.com/urfave/cli/command.go", line 210, in cli.Command.Run
  File "github.com/mobingi/alm-agent/vendor/github.com/urfave/cli/app.go", line 255, in cli.(*App).Run
  File "github.com/mobingi/alm-agent/main.go", line 202, in main.main
  File "/usr/local/go/src/runtime/proc.go", line 198, in runtime.main
  File "/usr/local/go/src/runtime/asm_amd64.s", line 2361, in runtime.goexit
{1a5c186c}: runtime error: invalid memory address or nil pointer dereference
```